### PR TITLE
Use more basic registries.conf

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,7 @@ mkdir -p "${PREFIX}/etc/containers"
 mkdir -p "${PREFIX}/share/containers"
 
 mkdir "${PREFIX}/etc/containers/registries.conf.d"
-cp buildah/tests/registries.conf "${PREFIX}/etc/containers/"
+cp $RECIPE_DIR/config/registries.conf "${PREFIX}/etc/containers/"
 
 mkdir "${PREFIX}/etc/containers/registries.d"
 cp skopeo/default.yaml "${PREFIX}/etc/containers/registries.d/"

--- a/recipe/config/README.md
+++ b/recipe/config/README.md
@@ -1,0 +1,5 @@
+# Default configurations to include in package
+
+This directory contains default configurations to include in the distribution package. The configurations are meant to represent un-opinionated and unintrusive defaults.
+
+* `registries.conf`: Numerous projects have their own versions of registries.conf. The version included here was originally obtained from the [buildah](https://github.com/containers/buildah/blob/21badab8885d2bd6422b2844608dab7d9e2035d1/docs/samples/registries.conf) repository.

--- a/recipe/config/registries.conf
+++ b/recipe/config/registries.conf
@@ -1,0 +1,25 @@
+# This is a system-wide configuration file used to
+# keep track of registries for various container backends.
+# It adheres to TOML format and does not support recursive
+# lists of registries.
+
+# The default location for this configuration file is /etc/containers/registries.conf.
+
+# The only valid categories are: 'registries.search', 'registries.insecure',
+# and 'registries.block'.
+
+[registries.search]
+registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
+
+# If you need to access insecure registries, add the registry's fully-qualified name.
+# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+[registries.insecure]
+registries = []
+
+
+# If you need to block pull access from a registry, uncomment the section below
+# and add the registries fully-qualified name.
+#
+# Docker only
+[registries.block]
+registries = []

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,9 @@ source:
   - url: https://github.com/containers/skopeo/archive/v1.13.3.tar.gz
     sha256: 0b788fc5725ac79327f7c29797821a2bafc1c3c87bbfcb2998c2a1be949e314d
     folder: skopeo
-  # NOTE: When updating to a newer buildah source archive,
-  #        1. check if registries.conf has already been added to containers-common,
-  #        2. make sure that tests/registries.conf is a plain and simple as of version 1.17.0.
-  - url: https://github.com/containers/buildah/archive/v1.32.0.tar.gz
-    sha256: 806ed541ea3cc761e0fa2dde8c6ee2d6ed258baf1cc5bd72b6b0cf1e876dda15
-    folder: buildah
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Until now, we have packaged `registries.conf` by pulling it from the `buildah` repo. In #11, we updated the buildah repo tag, which made `registries.conf` more opiniated than we had realized. IMO, if we package `registries.conf` in this package, it should be as bland as possible, providing a reasonable default without surprising users with opinionated defaults. Since there seems to be no canonical source for a default `registries.conf` file, I have now vendored the previous default  version of the file into the feedstock repository. My expectation is that this file never needs to be updated.